### PR TITLE
Fix ArgumentError interpolation

### DIFF
--- a/lib/mux_ruby/models/asset.rb
+++ b/lib/mux_ruby/models/asset.rb
@@ -271,7 +271,7 @@ module MuxRuby
     def max_stored_resolution=(max_stored_resolution)
       validator = EnumAttributeValidator.new('String', ['Audio only', 'SD', 'HD', 'FHD', 'UHD'])
       unless validator.valid?(max_stored_resolution)
-        fail ArgumentError, 'invalid value for "max_stored_resolution", must be one of #{validator.allowable_values}.'
+        fail ArgumentError, "invalid value for 'max_stored_resolution', must be one of #{validator.allowable_values}."
       end
       @max_stored_resolution = max_stored_resolution
     end
@@ -281,7 +281,7 @@ module MuxRuby
     def master_access=(master_access)
       validator = EnumAttributeValidator.new('String', ['temporary', 'none'])
       unless validator.valid?(master_access)
-        fail ArgumentError, 'invalid value for "master_access", must be one of #{validator.allowable_values}.'
+        fail ArgumentError, "invalid value for 'master_access', must be one of #{validator.allowable_values}."
       end
       @master_access = master_access
     end
@@ -291,7 +291,7 @@ module MuxRuby
     def mp4_support=(mp4_support)
       validator = EnumAttributeValidator.new('String', ['standard', 'none'])
       unless validator.valid?(mp4_support)
-        fail ArgumentError, 'invalid value for "mp4_support", must be one of #{validator.allowable_values}.'
+        fail ArgumentError, "invalid value for 'mp4_support', must be one of #{validator.allowable_values}."
       end
       @mp4_support = mp4_support
     end

--- a/lib/mux_ruby/models/asset_non_standard_input_reasons.rb
+++ b/lib/mux_ruby/models/asset_non_standard_input_reasons.rb
@@ -157,7 +157,7 @@ module MuxRuby
     def video_gop_size=(video_gop_size)
       validator = EnumAttributeValidator.new('String', ['high'])
       unless validator.valid?(video_gop_size)
-        fail ArgumentError, 'invalid value for "video_gop_size", must be one of #{validator.allowable_values}.'
+        fail ArgumentError, "invalid value for 'video_gop_size', must be one of #{validator.allowable_values}."
       end
       @video_gop_size = video_gop_size
     end
@@ -167,7 +167,7 @@ module MuxRuby
     def video_edit_list=(video_edit_list)
       validator = EnumAttributeValidator.new('String', ['non-standard'])
       unless validator.valid?(video_edit_list)
-        fail ArgumentError, 'invalid value for "video_edit_list", must be one of #{validator.allowable_values}.'
+        fail ArgumentError, "invalid value for 'video_edit_list', must be one of #{validator.allowable_values}."
       end
       @video_edit_list = video_edit_list
     end
@@ -177,7 +177,7 @@ module MuxRuby
     def audio_edit_list=(audio_edit_list)
       validator = EnumAttributeValidator.new('String', ['non-standard'])
       unless validator.valid?(audio_edit_list)
-        fail ArgumentError, 'invalid value for "audio_edit_list", must be one of #{validator.allowable_values}.'
+        fail ArgumentError, "invalid value for 'audio_edit_list', must be one of #{validator.allowable_values}."
       end
       @audio_edit_list = audio_edit_list
     end
@@ -187,7 +187,7 @@ module MuxRuby
     def unexpected_media_file_parameters=(unexpected_media_file_parameters)
       validator = EnumAttributeValidator.new('String', ['non-standard'])
       unless validator.valid?(unexpected_media_file_parameters)
-        fail ArgumentError, 'invalid value for "unexpected_media_file_parameters", must be one of #{validator.allowable_values}.'
+        fail ArgumentError, "invalid value for 'unexpected_media_file_parameters', must be one of #{validator.allowable_values}."
       end
       @unexpected_media_file_parameters = unexpected_media_file_parameters
     end

--- a/lib/mux_ruby/models/asset_static_renditions.rb
+++ b/lib/mux_ruby/models/asset_static_renditions.rb
@@ -91,7 +91,7 @@ module MuxRuby
     def status=(status)
       validator = EnumAttributeValidator.new('String', ['ready', 'preparing', 'disabled', 'errored'])
       unless validator.valid?(status)
-        fail ArgumentError, 'invalid value for "status", must be one of #{validator.allowable_values}.'
+        fail ArgumentError, "invalid value for 'status', must be one of #{validator.allowable_values}."
       end
       @status = status
     end

--- a/lib/mux_ruby/models/asset_static_renditions.rb
+++ b/lib/mux_ruby/models/asset_static_renditions.rb
@@ -7,7 +7,10 @@ require 'date'
 
 module MuxRuby
   class AssetStaticRenditions
-    # * `ready`: All MP4s are downloadable * `preparing`: We are preparing the MP4s * `disabled`: MP4 support was not requested or has been removed * `errored`: There was a Mux internal error that prevented the MP4s from being created 
+    # * `ready`: All MP4s are downloadable
+    # * `preparing`: We are preparing the MP4s
+    # * `disabled`: MP4 support was not requested or has been removed
+    # * `errored`: There was a Mux internal error that prevented the MP4s from being created
     attr_accessor :status
 
     attr_accessor :files

--- a/lib/mux_ruby/models/asset_static_renditions_files.rb
+++ b/lib/mux_ruby/models/asset_static_renditions_files.rb
@@ -124,7 +124,7 @@ module MuxRuby
     def name=(name)
       validator = EnumAttributeValidator.new('String', ['low.mp4', 'medium.mp4', 'high.mp4', 'audio.m4a'])
       unless validator.valid?(name)
-        fail ArgumentError, 'invalid value for "name", must be one of #{validator.allowable_values}.'
+        fail ArgumentError, "invalid value for 'name', must be one of #{validator.allowable_values}."
       end
       @name = name
     end
@@ -134,7 +134,7 @@ module MuxRuby
     def ext=(ext)
       validator = EnumAttributeValidator.new('String', ['mp4', 'm4a'])
       unless validator.valid?(ext)
-        fail ArgumentError, 'invalid value for "ext", must be one of #{validator.allowable_values}.'
+        fail ArgumentError, "invalid value for 'ext', must be one of #{validator.allowable_values}."
       end
       @ext = ext
     end

--- a/lib/mux_ruby/models/create_asset_request.rb
+++ b/lib/mux_ruby/models/create_asset_request.rb
@@ -143,7 +143,7 @@ module MuxRuby
     def mp4_support=(mp4_support)
       validator = EnumAttributeValidator.new('String', ['none', 'standard'])
       unless validator.valid?(mp4_support)
-        fail ArgumentError, 'invalid value for "mp4_support", must be one of #{validator.allowable_values}.'
+        fail ArgumentError, "invalid value for 'mp4_support', must be one of #{validator.allowable_values}."
       end
       @mp4_support = mp4_support
     end
@@ -153,7 +153,7 @@ module MuxRuby
     def master_access=(master_access)
       validator = EnumAttributeValidator.new('String', ['none', 'temporary'])
       unless validator.valid?(master_access)
-        fail ArgumentError, 'invalid value for "master_access", must be one of #{validator.allowable_values}.'
+        fail ArgumentError, "invalid value for 'master_access', must be one of #{validator.allowable_values}."
       end
       @master_access = master_access
     end

--- a/lib/mux_ruby/models/create_track_request.rb
+++ b/lib/mux_ruby/models/create_track_request.rb
@@ -148,7 +148,7 @@ module MuxRuby
     def type=(type)
       validator = EnumAttributeValidator.new('String', ['text'])
       unless validator.valid?(type)
-        fail ArgumentError, 'invalid value for "type", must be one of #{validator.allowable_values}.'
+        fail ArgumentError, "invalid value for 'type', must be one of #{validator.allowable_values}."
       end
       @type = type
     end
@@ -158,7 +158,7 @@ module MuxRuby
     def text_type=(text_type)
       validator = EnumAttributeValidator.new('String', ['subtitles'])
       unless validator.valid?(text_type)
-        fail ArgumentError, 'invalid value for "text_type", must be one of #{validator.allowable_values}.'
+        fail ArgumentError, "invalid value for 'text_type', must be one of #{validator.allowable_values}."
       end
       @text_type = text_type
     end

--- a/lib/mux_ruby/models/input_settings.rb
+++ b/lib/mux_ruby/models/input_settings.rb
@@ -137,7 +137,7 @@ module MuxRuby
     def type=(type)
       validator = EnumAttributeValidator.new('String', ['video', 'audio', 'text'])
       unless validator.valid?(type)
-        fail ArgumentError, 'invalid value for "type", must be one of #{validator.allowable_values}.'
+        fail ArgumentError, "invalid value for 'type', must be one of #{validator.allowable_values}."
       end
       @type = type
     end
@@ -147,7 +147,7 @@ module MuxRuby
     def text_type=(text_type)
       validator = EnumAttributeValidator.new('String', ['subtitles'])
       unless validator.valid?(text_type)
-        fail ArgumentError, 'invalid value for "text_type", must be one of #{validator.allowable_values}.'
+        fail ArgumentError, "invalid value for 'text_type', must be one of #{validator.allowable_values}."
       end
       @text_type = text_type
     end

--- a/lib/mux_ruby/models/input_settings_overlay_settings.rb
+++ b/lib/mux_ruby/models/input_settings_overlay_settings.rb
@@ -128,7 +128,7 @@ module MuxRuby
     def vertical_align=(vertical_align)
       validator = EnumAttributeValidator.new('String', ['top', 'middle', 'bottom'])
       unless validator.valid?(vertical_align)
-        fail ArgumentError, 'invalid value for "vertical_align", must be one of #{validator.allowable_values}.'
+        fail ArgumentError, "invalid value for 'vertical_align', must be one of #{validator.allowable_values}."
       end
       @vertical_align = vertical_align
     end
@@ -138,7 +138,7 @@ module MuxRuby
     def horizontal_align=(horizontal_align)
       validator = EnumAttributeValidator.new('String', ['left', 'center', 'right'])
       unless validator.valid?(horizontal_align)
-        fail ArgumentError, 'invalid value for "horizontal_align", must be one of #{validator.allowable_values}.'
+        fail ArgumentError, "invalid value for 'horizontal_align', must be one of #{validator.allowable_values}."
       end
       @horizontal_align = horizontal_align
     end

--- a/lib/mux_ruby/models/simulcast_target.rb
+++ b/lib/mux_ruby/models/simulcast_target.rb
@@ -13,7 +13,12 @@ module MuxRuby
     # Arbitrary Metadata set when creating a simulcast target.
     attr_accessor :passthrough
 
-    # The current status of the simulcast target. See Statuses below for detailed description.   * `idle`: Default status. When the parent live stream is in disconnected status, simulcast targets will be idle state.   * `starting`: The simulcast target transitions into this state when the parent live stream transition into connected state.   * `broadcasting`: The simulcast target has successfully connected to the third party live streaming service and is pushing video to that service.   * `errored`: The simulcast target encountered an error either while attempting to connect to the third party live streaming service, or mid-broadcasting. Compared to other errored statuses in the Mux Video API, a simulcast may transition back into the broadcasting state if a connection with the service can be re-established. 
+    # The current status of the simulcast target. See Statuses below for detailed description.
+    # * `idle`: Default status. When the parent live stream is in disconnected status, simulcast targets will be idle state.
+    # * `starting`: The simulcast target transitions into this state when the parent live stream transition into connected state.
+    # * `broadcasting`: The simulcast target has successfully connected to the third party live streaming service and is pushing video to that service.
+    # * `errored`: The simulcast target encountered an error either while attempting to connect to the third party live streaming service, or mid-broadcasting.
+    # Compared to other errored statuses in the Mux Video API, a simulcast may transition back into the broadcasting state if a connection with the service can be re-established.
     attr_accessor :status
 
     # Stream Key represents an stream identifier for the third party live streaming service to simulcast the parent live stream too.

--- a/lib/mux_ruby/models/simulcast_target.rb
+++ b/lib/mux_ruby/models/simulcast_target.rb
@@ -115,7 +115,7 @@ module MuxRuby
     def status=(status)
       validator = EnumAttributeValidator.new('String', ['idle', 'starting', 'broadcasting', 'errored'])
       unless validator.valid?(status)
-        fail ArgumentError, 'invalid value for "status", must be one of #{validator.allowable_values}.'
+        fail ArgumentError, "invalid value for 'status', must be one of #{validator.allowable_values}."
       end
       @status = status
     end

--- a/lib/mux_ruby/models/track.rb
+++ b/lib/mux_ruby/models/track.rb
@@ -176,7 +176,7 @@ module MuxRuby
     def type=(type)
       validator = EnumAttributeValidator.new('String', ['video', 'audio', 'text'])
       unless validator.valid?(type)
-        fail ArgumentError, 'invalid value for "type", must be one of #{validator.allowable_values}.'
+        fail ArgumentError, "invalid value for 'type', must be one of #{validator.allowable_values}."
       end
       @type = type
     end
@@ -186,7 +186,7 @@ module MuxRuby
     def text_type=(text_type)
       validator = EnumAttributeValidator.new('String', ['subtitles'])
       unless validator.valid?(text_type)
-        fail ArgumentError, 'invalid value for "text_type", must be one of #{validator.allowable_values}.'
+        fail ArgumentError, "invalid value for 'text_type', must be one of #{validator.allowable_values}."
       end
       @text_type = text_type
     end

--- a/lib/mux_ruby/models/update_asset_master_access_request.rb
+++ b/lib/mux_ruby/models/update_asset_master_access_request.rb
@@ -79,7 +79,7 @@ module MuxRuby
     def master_access=(master_access)
       validator = EnumAttributeValidator.new('String', ['temporary', 'none'])
       unless validator.valid?(master_access)
-        fail ArgumentError, 'invalid value for "master_access", must be one of #{validator.allowable_values}.'
+        fail ArgumentError, "invalid value for 'master_access', must be one of #{validator.allowable_values}."
       end
       @master_access = master_access
     end

--- a/lib/mux_ruby/models/update_asset_mp4_support_request.rb
+++ b/lib/mux_ruby/models/update_asset_mp4_support_request.rb
@@ -79,7 +79,7 @@ module MuxRuby
     def mp4_support=(mp4_support)
       validator = EnumAttributeValidator.new('String', ['standard', 'none'])
       unless validator.valid?(mp4_support)
-        fail ArgumentError, 'invalid value for "mp4_support", must be one of #{validator.allowable_values}.'
+        fail ArgumentError, "invalid value for 'mp4_support', must be one of #{validator.allowable_values}."
       end
       @mp4_support = mp4_support
     end

--- a/lib/mux_ruby/models/upload.rb
+++ b/lib/mux_ruby/models/upload.rb
@@ -172,7 +172,7 @@ module MuxRuby
     def status=(status)
       validator = EnumAttributeValidator.new('String', ['waiting', 'asset_created', 'errored', 'cancelled', 'timed_out'])
       unless validator.valid?(status)
-        fail ArgumentError, 'invalid value for "status", must be one of #{validator.allowable_values}.'
+        fail ArgumentError, "invalid value for 'status', must be one of #{validator.allowable_values}."
       end
       @status = status
     end


### PR DESCRIPTION
We were seeing errors in our logs as:

```
invalid value for "name", must be one of #{validator.allowable_values}.
```

instead of the expected

```
invalid value for "name", must be one of 'low.mp4', 'medium.mp4', 'high.mp4', 'audio.m4a'.
```

This PR fixes the interpolation of these values.