### PR TITLE
Add source_code_uri to the gemspec

### DIFF
--- a/mux_ruby.gemspec
+++ b/mux_ruby.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.description = "Ruby API wrapper for Mux"
   s.license     = "MIT"
   s.required_ruby_version = ">= 1.9"
+  s.metadata    = { "source_code_uri" => "https://github.com/muxinc/mux-ruby" }
 
   s.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
   s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'


### PR DESCRIPTION
This PR helps users access to the github repository from the rubygems.org page. It will be appended to the links sections under the source code key.