### PR TITLE
Add the source code URI in the gemspec

### DIFF
--- a/mux_ruby.gemspec
+++ b/mux_ruby.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://docs.mux.com"
   s.summary     = "Mux API Ruby Gem"
   s.description = "The Ruby client for Mux Data and Mux Video."
+  s.metadata    = { source_code_uri: "https://github.com/muxinc/mux-ruby" }
   s.license     = "MIT"
   s.required_ruby_version = ">= 2.4"
 

--- a/mux_ruby.gemspec
+++ b/mux_ruby.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://docs.mux.com"
   s.summary     = "Mux API Ruby Gem"
   s.description = "The Ruby client for Mux Data and Mux Video."
-  s.metadata    = { source_code_uri: "https://github.com/muxinc/mux-ruby" }
+  s.metadata    = { "source_code_uri" => "https://github.com/muxinc/mux-ruby" }
   s.license     = "MIT"
   s.required_ruby_version = ">= 2.4"
 


### PR DESCRIPTION
I've noticed that the source code URI was missing, which makes it difficult to find the source code from rubygems.org.
I think that dependabot is using it as well to create a proper changelog when opening a pull request.